### PR TITLE
rename media-streaming service to document-management

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ const CONFIG = {
       repo: 'https://github.com/bitwarden/server',
       features: ['Passwort-Sharing', 'Zwei-Faktor-Authentifizierung', 'Audit-Logs', 'API-Zugriff']
     },
-    'media-streaming': {
+    'document-management': {
       name: 'Dokumenten-Management',
       software: 'Paperless-ngx',
       icon: 'fas fa-file-alt',
@@ -181,8 +181,8 @@ class StackyApp {
   
   updateDataTypeVisibility() {
     // This will be called when services are toggled or when entering the config screen
-    const needsDataType = this.selectedServices.has('cloud-storage') || 
-                          this.selectedServices.has('media-streaming');
+    const needsDataType = this.selectedServices.has('cloud-storage') ||
+                          this.selectedServices.has('document-management');
     
     const dataTypeGroup = document.getElementById('data-type-group');
     if (dataTypeGroup) {
@@ -213,8 +213,8 @@ class StackyApp {
     };
     
     // Only include dataType if relevant services are selected
-    const needsDataType = this.selectedServices.has('cloud-storage') || 
-                          this.selectedServices.has('media-streaming');
+    const needsDataType = this.selectedServices.has('cloud-storage') ||
+                          this.selectedServices.has('document-management');
     
     if (needsDataType) {
       config.dataType = document.getElementById('data-type').value;
@@ -236,8 +236,8 @@ class StackyApp {
     }
 
     // Only validate dataType if relevant services are selected
-    const needsDataType = this.selectedServices.has('cloud-storage') || 
-                          this.selectedServices.has('media-streaming');
+    const needsDataType = this.selectedServices.has('cloud-storage') ||
+                          this.selectedServices.has('document-management');
     
     if (needsDataType && !config.dataType) {
       errors.push('Bitte wählen Sie einen Datentyp aus');

--- a/index.html
+++ b/index.html
@@ -59,10 +59,10 @@
              tabindex="0" 
              role="button"
              aria-pressed="false"
-             data-service="media-streaming"
+               data-service="document-management"
              onclick="app.toggleService(this)"
              onkeydown="app.handleKeyDown(event, this)">
-          <i class="fas fa-play-circle" aria-hidden="true"></i>
+            <i class="fas fa-file-alt" aria-hidden="true"></i>
           <h3>Dokumenten-Management</h3>
           <p>Versionierung & Workflow-Automatisierung</p>
         </div>


### PR DESCRIPTION
## Summary
- update service key from `media-streaming` to `document-management`
- adjust logic to check `document-management` selections
- update data attributes and icon in HTML

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_684e92621e5483229efe0ce16c62d0e2