### PR TITLE
Fix dark mode card backgrounds

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -148,7 +148,7 @@ body {
 }
 
 .service-category {
-  background: white;
+  background: var(--card-bg);
   padding: 24px 20px;
   border-radius: var(--radius);
   box-shadow: var(--shadow);
@@ -200,7 +200,7 @@ body {
   padding: 12px 16px;
   border: 1px solid #ced4da;
   border-radius: var(--radius);
-  background: white;
+  background: var(--card-bg);
   color: var(--text-dark);
   font-size: 1rem;
   transition: var(--transition);
@@ -219,7 +219,7 @@ body {
 .suggestion,
 .hardware-recommendation,
 .amortization-calculator {
-  background: white;
+  background: var(--card-bg);
   padding: 24px;
   border-radius: var(--radius);
   box-shadow: var(--shadow);


### PR DESCRIPTION
## Summary
- use --card-bg variable for card elements
- makes text readable in dark mode

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ea6eab9148322b6209e65ae35586b